### PR TITLE
Add `--all` option for `rubocop --auto-correct-all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ $ bundle exec rubocop_auto_corrector
 $ bundle exec rubocop_auto_corrector --help
 Usage: rubocop_auto_corrector [options]
         --auto-correct-count COUNT   Run `rubocop --auto-correct` and `git commit` for this number of times. (default. 2)
+        --all                        Whether run `rubocop` with `--auto-correct-all`. (default. run with `--auto-correct`)
 ```
 
 ## Development

--- a/exe/rubocop_auto_corrector
+++ b/exe/rubocop_auto_corrector
@@ -7,7 +7,8 @@ require 'optparse'
 
 opt = OptionParser.new
 params = {
-  auto_correct_count: 2
+  auto_correct_count: 2,
+  auto_correct_all: false
 }
 
 Version = RubocopAutoCorrector::VERSION
@@ -19,10 +20,14 @@ opt.on(
   params[:auto_correct_count] = v.to_i
 end
 
+opt.on('--all', 'Whether run `rubocop` with `--auto-correct-all`. (default. run with `--auto-correct`)') do
+  params[:auto_correct_all] = true
+end
+
 opt.parse!(ARGV)
 
 cli = RubocopAutoCorrector::CLI.new
 
 params[:auto_correct_count].times do
-  cli.perform
+  cli.perform(params[:auto_correct_all])
 end

--- a/lib/rubocop_auto_corrector/cli.rb
+++ b/lib/rubocop_auto_corrector/cli.rb
@@ -15,7 +15,9 @@ module RubocopAutoCorrector
       @exclude_cops = data['exclude_cops']
     end
 
-    def perform
+    def perform(auto_collect_all)
+      rubocop_option = auto_collect_all ? '--auto-correct-all' : '--auto-correct'
+
       cop_names = collect_offense_cop_names.select { |cop_name| auto_correctable?(cop_name) }
                                            .sort_by { |cop_name| [cop_order(cop_name), cop_name] }
 
@@ -25,7 +27,7 @@ module RubocopAutoCorrector
           next
         end
 
-        run_and_commit "rubocop --auto-correct --only #{cop_name}"
+        run_and_commit "rubocop #{rubocop_option} --only #{cop_name}"
       end
     end
 

--- a/rubocop_auto_corrector.gemspec
+++ b/rubocop_auto_corrector.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.4.0'
 
-  spec.add_dependency 'rubocop', '>= 0.82.0'
+  spec.add_dependency 'rubocop', '>= 0.87.0'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'coveralls'

--- a/spec/dummy/.rubocop.yml
+++ b/spec/dummy/.rubocop.yml
@@ -1,2 +1,5 @@
+AllCops:
+  NewCops: enable
+
 Style/FrozenStringLiteralComment:
   Enabled: false

--- a/spec/exe/rubocop_auto_corrector_spec.rb
+++ b/spec/exe/rubocop_auto_corrector_spec.rb
@@ -3,7 +3,15 @@
 RSpec.describe './exe/rubocop_auto_corrector' do
   include_context 'setup dummy repo'
 
-  it 'running' do
-    system! "#{spec_dir}/../exe/rubocop_auto_corrector"
+  context 'without arg' do
+    it 'running' do
+      system! "#{spec_dir}/../exe/rubocop_auto_corrector"
+    end
+  end
+
+  context 'with --all' do
+    it 'running' do
+      system! "#{spec_dir}/../exe/rubocop_auto_corrector --all"
+    end
   end
 end

--- a/spec/rubocop_auto_corrector/cli_spec.rb
+++ b/spec/rubocop_auto_corrector/cli_spec.rb
@@ -4,36 +4,73 @@ RSpec.describe RubocopAutoCorrector::CLI do
   let(:cli) { RubocopAutoCorrector::CLI.new }
 
   describe '#perform' do
-    subject { cli.perform }
+    subject { cli.perform(auto_collect_all) }
 
     include_context 'setup dummy repo'
 
-    it 'auto correct and commit' do
-      subject
+    context 'when auto_collect_all is false' do
+      let(:auto_collect_all) { false }
 
-      example1 = File.read('example1.rb')
-      example2 = File.read('example2.rb')
+      it 'auto correct and commit' do
+        subject
 
-      git_log = `git --no-pager log --oneline`.strip
-      rubocop_commits = git_log.each_line.reject { |line| line =~ /Initial commit/ }
+        example1 = File.read('example1.rb')
+        example2 = File.read('example2.rb')
 
-      aggregate_failures do
-        expect(example1).to eq(<<~RUBY)
-          def badName
-            test if something
-          end
-        RUBY
+        git_log = `git --no-pager log --oneline`.strip
+        rubocop_commits = git_log.each_line.reject { |line| line =~ /Initial commit/ }
 
-        expect(example2).to eq(<<~RUBY)
-          class Foo
-            def self.someMethod
-              puts 'test'
+        aggregate_failures do
+          expect(example1).to eq(<<~RUBY)
+            def badName
+              test if something
             end
-          end
-        RUBY
+          RUBY
 
-        expect(rubocop_commits.count).to be >= 1
-        expect(rubocop_commits).to all(match(/^[0-9a-z]{7} :cop: rubocop --auto-correct --only /))
+          expect(example2).to eq(<<~RUBY)
+            class Foo
+              def self.someMethod
+                puts 'test'
+              end
+            end
+          RUBY
+
+          expect(rubocop_commits.count).to be >= 1
+          expect(rubocop_commits).to all(match(/^[0-9a-z]{7} :cop: rubocop --auto-correct --only /))
+        end
+      end
+    end
+
+    context 'when auto_collect_all is true' do
+      let(:auto_collect_all) { true }
+
+      it 'auto correct and commit' do
+        subject
+
+        example1 = File.read('example1.rb')
+        example2 = File.read('example2.rb')
+
+        git_log = `git --no-pager log --oneline`.strip
+        rubocop_commits = git_log.each_line.reject { |line| line =~ /Initial commit/ }
+
+        aggregate_failures do
+          expect(example1).to eq(<<~RUBY)
+            def badName
+              test if something
+            end
+          RUBY
+
+          expect(example2).to eq(<<~RUBY)
+            class Foo
+              def self.someMethod
+                puts 'test'
+              end
+            end
+          RUBY
+
+          expect(rubocop_commits.count).to be >= 1
+          expect(rubocop_commits).to all(match(/^[0-9a-z]{7} :cop: rubocop --auto-correct-all --only /))
+        end
       end
     end
   end


### PR DESCRIPTION
When `--all` arg is passed to `rubocop_auto_corrector`, run `rubocop --auto-correct-all && git commit` with each cop.

e.g. `rubocop_auto_corrector --all`

Close #33