### PR TITLE
Fixed. `auto_correctable?` doesn't work when cop has `.support_autocorrect?` and doesn't have `#autocorrect`

### DIFF
--- a/lib/rubocop_auto_corrector/cop_finder.rb
+++ b/lib/rubocop_auto_corrector/cop_finder.rb
@@ -17,6 +17,8 @@ module RubocopAutoCorrector
           require '#{gem_name}'
         rescue LoadError
         end
+
+        return #{cop_class_name}.support_autocorrect? if #{cop_class_name}.respond_to?(:support_autocorrect?)
         #{cop_class_name}.new.respond_to?(:autocorrect)
       RUBY
     rescue NameError


### PR DESCRIPTION
e.g. [`FactoryBot/CreateList`](https://github.com/rubocop-hq/rubocop-rspec/blob/v1.42.0/lib/rubocop/cop/rspec/factory_bot/create_list.rb)

https://github.com/sue445/rubocop_auto_corrector/runs/857514039?check_suite_focus=true

`.support_autocorrect?` is available since rubocop v0.87.0

https://github.com/rubocop-hq/rubocop/compare/v0.86.0...v0.87.0#diff-800a94c24ccc426ca3158426d876c397