### PR TITLE
Requires rubocop v1.13.0+ and drop ruby 2.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ jobs:
 
       matrix:
         ruby:
-          - ruby:2.4
           - ruby:2.5
           - ruby:2.6
           - ruby:2.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,6 @@ jobs:
         with:
           codeclimate-test-reporter-id: ${{ secrets.CC_TEST_REPORTER_ID }}
           command: after-build
-        if: matrix.ruby >= 'ruby:2.4' && always()
         continue-on-error: true
 
       - name: Slack Notification (not success)

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  # rubocop 1.13.0+ requires ruby 2.5+
+  TargetRubyVersion: 2.5
 
   Exclude:
     - 'spec/dummy/**/*'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - '.git/**/*'
 
   NewCops: enable
+  SuggestExtensions: false
 
 Metrics/BlockLength:
   Exclude:

--- a/rubocop_auto_corrector.gemspec
+++ b/rubocop_auto_corrector.gemspec
@@ -35,9 +35,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
 
-  spec.add_dependency 'rubocop', '>= 0.87.0'
+  spec.add_dependency 'rubocop', '>= 1.13.0'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'coveralls'


### PR DESCRIPTION
Since rubocop 1.13.0, ruby 2.4 is droped.

https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#1130-2021-04-20